### PR TITLE
New logic to increment house number

### DIFF
--- a/RapidHouseNumbers.js
+++ b/RapidHouseNumbers.js
@@ -191,7 +191,7 @@
     // if the <return> key is released blur so that you can type <h> to add a house number rather than see it appended to the next value.
     $("input.rapidHN.next").keyup(evt => {
       if (evt.which === 13) {
-        this.blur();
+        evt.target.blur();
       }
     });
 

--- a/RapidHouseNumbers.js
+++ b/RapidHouseNumbers.js
@@ -179,7 +179,7 @@
                 <div class="toolbar-button rapidHN-input">
                     <span class="menu-title rapidHN-text">Increment</span>
                     <div class="rapidHN-text-input sm">
-                        <input type="number" name="incrementHN" class="rapidHN increment" value="${initialIncrement}" step="1">
+                        <input type="number" name="incrementHN" class="rapidHN increment" value="${initialIncrement}" min="1" step="1">
                     </div>
                 </div>
             </div>
@@ -202,7 +202,7 @@
     $("div.rapidHN-control input").on("change", () => {
       const controls = $("div.rapidHN-control");
       const rapidHNenabled = $("input.rapidHN.next", controls).filter(":visible").val()
-        && nonZero($("input.rapidHN.increment", controls));
+        && Number($("input.rapidHN.increment", controls)) > 0;
 
       if (rapidHNenabled) {
         if (houseNumbersObserver === undefined) {
@@ -351,11 +351,6 @@
     }
 
     nextElement.val(nextParts.reverse().join(''));
-  }
-
-  function nonZero(input) {
-    const i = parseInt(input.val(), 10);
-    return !isNaN(i) && i !== 0;
   }
 
   // Type 1-9 instead of 'h' to specify a one-time increment that be applied after the current "next" value is added to the map

--- a/RapidHouseNumbers.js
+++ b/RapidHouseNumbers.js
@@ -202,7 +202,7 @@
     $("div.rapidHN-control input").on("change", () => {
       const controls = $("div.rapidHN-control");
       const rapidHNenabled = $("input.rapidHN.next", controls).filter(":visible").val()
-        && Number($("input.rapidHN.increment", controls)) > 0;
+        && Number($("input.rapidHN.increment", controls).val()) > 0;
 
       if (rapidHNenabled) {
         if (houseNumbersObserver === undefined) {

--- a/RapidHouseNumbers.js
+++ b/RapidHouseNumbers.js
@@ -168,20 +168,12 @@
       window.localStorage.getItem("rapidHNincrement") || 2
     ).toString();
 
-    // NOTE: We have two input.rapidHN.next fields because the type property cannot be modified.  We, instead, create two fields
-    // then use a function, updateRapidHNnextVisibility, to determine which one is currently visible.
     $(addHouseNumberNode).after(`
             <div class="rapidHN-control">
                 <div class="toolbar-button rapidHN-input">
                     <span class="menu-title rapidHN-text">Next #</span>
                     <div class="rapidHN-text-input sm">
                         <input type="text" class="rapidHN next">
-                        <input type="number" class="rapidHN next">
-                    </div>
-                    <div id="rapidHN-input-type" class="rapidHN-switch-mode">
-                        <button id="current-input-type">1</button>
-                        <span class="tooltiptext" id="rapidHN-input-is-number">1,2,3</span>
-                        <span class="tooltiptext" id="rapidHN-input-is-text" style="display:none">1a,2b,3c & 12-3</span>
                     </div>
                 </div>
                 <div class="toolbar-button rapidHN-input">
@@ -193,18 +185,8 @@
             </div>
         `);
     rapidHNtoolbarButton = addHouseNumberNode.nextSibling;
-    updateRapidHNnextVisibility(false);
-
+    
     enableDisableControls(rapidHNtoolbarButton, W.map.getZoom() < 18);
-
-    $("button#current-input-type").click(() => {
-      let nextInputType = window.localStorage.getItem("rapidHNnextInputType") || "number";
-
-      nextInputType = { number: "text", text: "number" }[nextInputType];
-
-      window.localStorage.setItem("rapidHNnextInputType", nextInputType);
-      updateRapidHNnextVisibility(true);
-    });
 
     // if the <return> key is released blur so that you can type <h> to add a house number rather than see it appended to the next value.
     $("input.rapidHN.next").keyup(evt => {
@@ -446,30 +428,6 @@
     }
 
     return secondary;
-  }
-
-  function updateRapidHNnextVisibility(showTooltip) {
-    const nextInputType = window.localStorage.getItem("rapidHNnextInputType") || "number";
-    const inputs = $("input.rapidHN.next");
-
-    inputs.hide();
-    const nextInput = inputs.filter(`[type='${nextInputType}']`);
-    nextInput.show();
-
-    $("button#current-input-type").text(
-      { number: "1", text: "A" }[nextInputType],
-    );
-
-    if (showTooltip) {
-      // hide both tooltips
-      ["number", "text"].forEach(type => {
-        const tooltip = $(`span#rapidHN-input-is-${type}`);
-        tooltip.hide();
-      });
-
-      const tooltip = $(`span#rapidHN-input-is-${nextInputType}`);
-      tooltip.show();
-    }
   }
 
   rapidHNBootstrap();


### PR DESCRIPTION
This allows any house number format by breaking down the input into chunks that are processed individually as numbers or letters. Numbers are incremented normally, but letters will increment the prior chunk if they roll over past Z. Any non-digit/letter character and 0-padded numbers are maintained. The existing supported formats work exactly the same as before. The input format switch is also removed, as it serves no purpose.